### PR TITLE
Add sque command-line tool.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,13 +18,17 @@ my %WriteMakefileArgs = (
     "ExtUtils::MakeMaker" => "6.30"
   },
   "DISTNAME" => "Sque",
-  "EXE_FILES" => [],
+  "EXE_FILES" => [
+    "bin/sque"
+  ],
   "LICENSE" => "unrestricted",
   "NAME" => "Sque",
   "PREREQ_PM" => {
     "Any::Moose" => 0,
+    "App::Cmd::Setup" => 0,
     "JSON" => 0,
     "Net::STOMP::Client" => 0,
+    "Parallel::ForkManager" => 0,
     "Try::Tiny" => 0,
     "UNIVERSAL::require" => 0,
     "strict" => 0,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ In this case, the queue will be set automatically automatically to the
 job class name with colons replaced with hyphens, which in this
 case would be 'My-Task'.
 
+Additionally, the [sque](http://search.cpan.org/perldoc?sque) command-line tool can be used to send messages:
+
+    $ sque send -h 127.0.0.1 -p 61613 -c My::Task 'Hello world!'
+
 Background jobs can be any perl module that implement a perform() function.
 The [Sque::Job](http://search.cpan.org/perldoc?Sque::Job) object is passed as the only argument to this function:
 
@@ -58,7 +62,7 @@ with the [Sque::Job](http://search.cpan.org/perldoc?Sque::Job) object as the onl
     has attr => ( is => 'ro', default => 'Where am I?' );
 
     sub perform {
-        my ( $self, $job ) = shift;
+        my ( $self, $job ) = @_;
         say $self->attr;
         say $job->args->[0];
     }
@@ -73,6 +77,11 @@ to listen to one or more queues:
     my $w = Sque->new( stomp => '127.0.0.1:61613' )->worker;
     $w->add_queues('my_queue');
     $w->work;
+
+Or you can simply use the [sque](http://search.cpan.org/perldoc?sque) command-line tool which uses [App::Sque](http://search.cpan.org/perldoc?App::Sque)
+like so:
+
+    $ sque work --host 127.0.0.1 --port 61613 --workers 5 --lib ./lib --lib ./lib2 --queues Queue1,Queue2,Queue3
 
 # DESCRIPTION
 

--- a/bin/sque
+++ b/bin/sque
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+package sque;
+use App::Sque;
+
+# ABSTRACT: Sque command-line tool
+
+App::Sque->run;
+
+=head1 SYNOPSIS
+
+This is the sque command line tool.  It can be used to start workers:
+
+    $ sque work --host 127.0.0.1 --port 61613 --workers 5 --lib ./lib --queues Queue1,Queue2,Queue3
+
+or send messages to a queue:
+
+    $ sque send --host 127.0.0.1 --port 61613 --class My::Task --queue Queue1 arg1 arg2 arg3 ...
+
+=cut

--- a/lib/App/Sque.pm
+++ b/lib/App/Sque.pm
@@ -1,0 +1,6 @@
+package App::Sque;
+use App::Cmd::Setup -app;
+
+# ABSTRACT: Sque command-line tool
+
+1;

--- a/lib/App/Sque/Command/send.pm
+++ b/lib/App/Sque/Command/send.pm
@@ -1,0 +1,43 @@
+package App::Sque::Command::send;
+use App::Sque -command;
+use Sque;
+
+# ABSTRACT: Send command for sque command-line tool
+
+sub usage_desc { "Send sque message." }
+
+sub opt_spec {
+    return (
+        [ "class|c=s",  "Worker class to process message" ],
+        [ "host|h=s",  "Set the stomp host" ],
+        [ "port|p=i",  "Set the stomp port" ],
+        [ "queue|q=s",  "Queue to send message to, defaults to worker class" ],
+    );
+}
+
+sub validate_args {
+    my ($self, $opt, $args) = @_;
+
+    # We must have the host/part
+    $self->usage_error("host required") unless $opt->{host};
+    $self->usage_error("port required") unless $opt->{port};
+
+    # We must have class
+    $self->usage_error("class required") unless $opt->{class};
+
+    $self->usage_error("at least on arg required") unless @$args > 0;
+}
+
+sub execute {
+    my ($self, $opt, $args) = @_;
+
+    if( ! defined $opt->{queue} ){
+        $opt->{queue} = $opt->{class};
+        $opt->{queue} =~ s/://g;
+    }
+
+    Sque->new( stomp => "$opt->{host}:$opt->{port}" )
+        ->push( $opt->{queue} => { class => $opt->{class}, args => $args });
+}
+
+1;

--- a/lib/App/Sque/Command/work.pm
+++ b/lib/App/Sque/Command/work.pm
@@ -1,0 +1,57 @@
+package App::Sque::Command::work;
+use App::Sque -command;
+use Parallel::ForkManager;
+use Sque;
+
+# ABSTRACT: Worker command for sque command-line tool
+
+sub usage_desc { "Start sque worker(s)" }
+
+sub opt_spec {
+    return (
+        [ "host|h=s",  "Set the stomp host" ],
+        [ "lib|l=s@",  "Add a lib directory if needed to find worker classes" ],
+        [ "port|p=i",  "Set the stomp port" ],
+        [ "queues|q=s",  "Comma-separted list of queues to listen to" ],
+        [ "verbose|v",  "Be verbose?" ],
+        [ "workers|w=i",  "Number of workers to start", { default => 1 } ],
+    );
+}
+
+sub validate_args {
+    my ($self, $opt, $args) = @_;
+
+    # We must have the host/part
+    $self->usage_error("host required") unless $opt->{host};
+    $self->usage_error("port required") unless $opt->{port};
+
+    # We must have queues
+    $self->usage_error("queues required") unless $opt->{queues};
+}
+
+sub execute {
+    my ($self, $opt, $args) = @_;
+
+    # Use user-specified lib directories
+    unshift @INC, @{ $opt->{lib} };
+    my @queues = split /,/, $opt->{queues};
+
+    if($opt->{verbose}){
+        $" =", ";
+        print "Listening to: @queues with $opt->{workers} worker(s).\n";
+    }
+
+    $pm = new Parallel::ForkManager($opt->{workers});
+    while (1) {
+        my $pid = $pm->start and next;
+
+        my $w = Sque->new( stomp => "$opt->{host}:$opt->{port}" )->worker;
+        $w->verbose( $opt->{verbose} ? 1 : 0 );
+        $w->add_queues( @queues );
+        $w->work;
+
+        $pm->finish;
+    }
+}
+
+1;

--- a/lib/Sque.pm
+++ b/lib/Sque.pm
@@ -111,6 +111,10 @@ In this case, the queue will be set automatically automatically to the
 job class name with colons replaced with hyphens, which in this
 case would be 'My-Task'.
 
+Additionally, the L<sque> command-line tool can be used to send messages:
+
+    $ sque send -h 127.0.0.1 -p 61613 -c My::Task 'Hello world!'
+
 Background jobs can be any perl module that implement a perform() function.
 The L<Sque::Job> object is passed as the only argument to this function:
 
@@ -153,6 +157,11 @@ to listen to one or more queues:
     my $w = Sque->new( stomp => '127.0.0.1:61613' )->worker;
     $w->add_queues('my_queue');
     $w->work;
+
+Or you can simply use the L<sque> command-line tool which uses L<App::Sque>
+like so:
+
+    $ sque work --host 127.0.0.1 --port 61613 --workers 5 --lib ./lib --lib ./lib2 --queues Queue1,Queue2,Queue3
 
 =head1 DESCRIPTION
 

--- a/lib/Sque/Worker.pm
+++ b/lib/Sque/Worker.pm
@@ -1,9 +1,9 @@
 package Sque::Worker;
 use Any::Moose;
 use Any::Moose '::Util::TypeConstraints';
-with 'Sque::Encoder';
-
 use Try::Tiny;
+
+with 'Sque::Encoder';
 
 # ABSTRACT: Does the hard work of babysitting Sque::Job's
 


### PR DESCRIPTION
This adds the sque command-line tool with support for the work and send
commands.  It allows running a specified number of workers listening to a
number of queues.  The send command allows easy sending of messages to squeue
workers.
